### PR TITLE
edited processlog names in deploy _header, recompiled deploy.bats

### DIFF
--- a/automated_EGALLEY.bat
+++ b/automated_EGALLEY.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/bookmaker_test.bat
+++ b/bookmaker_test.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/egalley_swerve.bat
+++ b/egalley_swerve.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/final_swerve.bat
+++ b/final_swerve.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/generic.bat
+++ b/generic.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/pod_swerve.bat
+++ b/pod_swerve.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/sample_SMP.bat
+++ b/sample_SMP.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/standard_EGALLEY.bat
+++ b/standard_EGALLEY.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/standard_FINAL.bat
+++ b/standard_FINAL.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/standard_FIRSTPASS.bat
+++ b/standard_FIRSTPASS.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/swoon.bat
+++ b/swoon.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/templates/_header.bat
+++ b/templates/_header.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:

--- a/workflows_status.bat
+++ b/workflows_status.bat
@@ -39,8 +39,8 @@ set logfile="%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename
 if not exist "S:\resources\logs\processLogs" mkdir "S:\resources\logs\processLogs"
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=/:" %%a in ("%TIME%") do (set mytime=%%a%%b)
-set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinal.txt"
-set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_torDOTcomFinalTmp.txt"
+set p_log="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%.txt"
+set p_log_tmp="S:\resources\logs\processLogs\%basename%_%mydate%-%mytime%_%projectfolder%Tmp.txt"
 if exist "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" move "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\%basename%-stdout-and-err.txt" "%logfolder%\bookmaker_logs\%logsubfolder%\%projectfolder%\past\%basename%-stdout-and-err_ARCHIVED_%mydate%-%mytime%.txt"
 
 rem write scriptnames to file for ProcessLogger to rm on success:


### PR DESCRIPTION
Part 1 of fixing the mistaken 'torDOTcom' callout in processwatch alert emails.
(for this issue:  https://github.com/macmillanpublishers/bookmaker_deploy/issues/21https://github.com/macmillanpublishers/bookmaker_deploy/issues/21)
