### PR TITLE
Adding custom htmlmaker_postprocessing to egalleymaker .bat

### DIFF
--- a/automated_EGALLEY.bat
+++ b/automated_EGALLEY.bat
@@ -49,6 +49,7 @@ rem write scriptnames to file for ProcessLogger to rm on success:
   echo htmlmaker_preprocessing
   echo htmlmaker
   echo htmlmaker_postprocessing
+  echo egalleymaker_htmlmaker_postprocessing
   echo cacert
   echo titlepage
   echo metadata_preprocessing
@@ -80,6 +81,7 @@ C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\bookmaker\core\tmparchive
 C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\bookmaker_addons\htmlmaker_preprocessing.rb '%infile%' >> %logfile% 2>&1 && call :ProcessLogger htmlmaker_preprocessing
 C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\bookmaker\core\htmlmaker\htmlmaker.rb '%infile%' >> %logfile% 2>&1 && call :ProcessLogger htmlmaker
 C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\bookmaker_addons\htmlmaker_postprocessing.rb '%infile%' >> %logfile% 2>&1 && call :ProcessLogger htmlmaker_postprocessing
+C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\bookmaker_addons\egalleymaker_htmlmaker_postprocessing.rb '%infile%' >> %logfile% 2>&1 && call :ProcessLogger egalleymaker_htmlmaker_postprocessing
 SET SSL_CERT_FILE=C:\Ruby193\lib\ruby\site_ruby\1.9.1\rubygems\ssl_certs\cacert.pem >> %logfile% 2>&1 && call :ProcessLogger cacert
 C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\covermaker\bookmaker_titlepage.rb '%infile%' >> %logfile% 2>&1 && call :ProcessLogger titlepage
 C:\Ruby200\bin\ruby.exe S:\resources\bookmaker_scripts\bookmaker_addons\metadata_preprocessing.rb '%infile%' >> %logfile% 2>&1 && call :ProcessLogger metadata_preprocessing

--- a/scripts.json
+++ b/scripts.json
@@ -41,6 +41,14 @@
     "testvalue": "htmlmaker_postprocessing"
     },
     {
+    "name": "egalleymaker_htmlmaker_postprocessing",
+    "filetype": "rb",
+    "command": "RUBYCMD",
+    "location": "BKMKRADDONS\\egalleymaker_htmlmaker_postprocessing.rb",
+    "argv": "'%infile%' ",
+    "testvalue": "egalleymaker_htmlmaker_postprocessing"
+    },
+    {
     "name": "filearchive",
     "filetype": "rb",
     "command": "RUBYCMD",
@@ -519,6 +527,7 @@
       {"name": "htmlmaker_preprocessing"},
       {"name": "htmlmaker"},
       {"name": "htmlmaker_postprocessing"},
+      {"name": "egalleymaker_htmlmaker_postprocessing"},
       {"name": "cacert"},
       {"name": "bookmaker_titlepage"},
       {"name": "metadata_preprocessing"},


### PR DESCRIPTION
Adding an extra script to run after htmlmaker, that will strip images from files for egalleymaker, since no image files are provided with the manuscript.

Tested locally and on production.

See https://github.com/macmillanpublishers/bookmaker_addons/issues/103

@mattretzer or @ericawarren can you review and approve?
